### PR TITLE
dat 解析共享内存版 提速并降低磁盘 IO 消耗

### DIFF
--- a/IPMem.class.php
+++ b/IPMem.class.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+	全球 IPv4 地址归属地数据库(17MON.CN 版)
+	高春辉(pAUL gAO) <gaochunhui@gmail.com>
+	Build 20141009 版权所有 17MON.CN
+	(C) 2006 - 2014 保留所有权利
+	请注意及时更新 IP 数据库版本
+	数据问题请加 QQ 群: 346280296
+	Code for PHP 5.3+ only
+  Edited by @A-Circle-Zhang
+  PHP 需要开启 shmop 扩展
+*/
+
+class IP
+{
+	private static $ip	 = NULL;
+
+	private static $fp	 = NULL;
+	private static $offset = NULL;
+	private static $index  = NULL;
+
+	private static $cached = array();
+
+	public static function find($ip)
+	{
+		if (empty($ip) === TRUE)
+		{
+			return 'N/A';
+		}
+
+		$nip   = gethostbyname($ip);
+		$ipdot = explode('.', $nip);
+
+		if ($ipdot[0] < 0 || $ipdot[0] > 255 || count($ipdot) !== 4)
+		{
+			return 'N/A';
+		}
+
+		if (isset(self::$cached[$nip]) === TRUE)
+		{
+			return self::$cached[$nip];
+		}
+
+		if (self::$fp === NULL)
+		{
+			self::init();
+		}
+
+		$nip2 = pack('N', ip2long($nip));
+
+		$tmp_offset = (int)$ipdot[0] * 4;
+		$start	  = unpack('Vlen', self::$index[$tmp_offset] . self::$index[$tmp_offset + 1] . self::$index[$tmp_offset + 2] . self::$index[$tmp_offset + 3]);
+
+		$index_offset = $index_length = NULL;
+		$max_comp_len = self::$offset['len'] - 1024 - 4;
+		for ($start = $start['len'] * 8 + 1024; $start < $max_comp_len; $start += 8)
+		{
+			if (self::$index{$start} . self::$index{$start + 1} . self::$index{$start + 2} . self::$index{$start + 3} >= $nip2)
+			{
+				$index_offset = unpack('Vlen', self::$index{$start + 4} . self::$index{$start + 5} . self::$index{$start + 6} . "\x0");
+				$index_length = unpack('Clen', self::$index{$start + 7});
+
+				break;
+			}
+		}
+
+		if ($index_offset === NULL)
+		{
+			return 'N/A';
+		}
+
+		self::$cached[$nip] = explode("\t", shmop_read(self::$fp, self::$offset['len'] + $index_offset['len'] - 1024, $index_length['len']));
+
+		return self::$cached[$nip];
+	}
+
+	private static function init()
+	{
+		if (self::$fp === NULL)
+		{
+			self::$ip = new self();
+			$sharedFile = __DIR__ . '/17monipdb.dat';
+			$f2k = ftok($sharedFile, 't');
+			self::$fp = shmop_open($f2k, 'a', 0, 0);
+			if(self::$fp === FALSE){
+				self::$fp = shmop_open($f2k, 'c', 0644, filesize($sharedFile));
+				shmop_write(self::$fp, file_get_contents($sharedFile), 0);
+			}
+			if (self::$fp === FALSE)
+			{
+				throw new Exception('Invalid 17monipdb.dat file!');
+			}
+			self::$offset = unpack('Nlen', shmop_read(self::$fp, 0, 4));
+			if (self::$offset['len'] < 4)
+			{
+				throw new Exception('Invalid 17monipdb.dat file!');
+			}
+
+			self::$index = shmop_read(self::$fp, 4, self::$offset['len'] - 4);
+		}
+	}
+
+	public function __destruct()
+	{
+		if (self::$fp !== NULL)
+		{
+			shmop_close(self::$fp);
+		}
+	}
+}
+
+?>

--- a/IPMem.class.php
+++ b/IPMem.class.php
@@ -1,113 +1,113 @@
 <?php
 
 /*
-	全球 IPv4 地址归属地数据库(17MON.CN 版)
-	高春辉(pAUL gAO) <gaochunhui@gmail.com>
-	Build 20141009 版权所有 17MON.CN
-	(C) 2006 - 2014 保留所有权利
-	请注意及时更新 IP 数据库版本
-	数据问题请加 QQ 群: 346280296
-	Code for PHP 5.3+ only
-  Edited by @A-Circle-Zhang
-  PHP 需要开启 shmop 扩展
+    全球 IPv4 地址归属地数据库(17MON.CN 版)
+    高春辉(pAUL gAO) <gaochunhui@gmail.com>
+    Build 20141009 版权所有 17MON.CN
+    (C) 2006 - 2014 保留所有权利
+    请注意及时更新 IP 数据库版本
+    数据问题请加 QQ 群: 346280296
+    Code for PHP 5.3+ only
+    Edited by @A-Circle-Zhang
+    PHP 需要开启 shmop 扩展
 */
 
 class IP
 {
-	private static $ip	 = NULL;
+    private static $ip     = NULL;
 
-	private static $fp	 = NULL;
-	private static $offset = NULL;
-	private static $index  = NULL;
+    private static $fp     = NULL;
+    private static $offset = NULL;
+    private static $index  = NULL;
 
-	private static $cached = array();
+    private static $cached = array();
 
-	public static function find($ip)
-	{
-		if (empty($ip) === TRUE)
-		{
-			return 'N/A';
-		}
+    public static function find($ip)
+    {
+        if (empty($ip) === TRUE)
+        {
+            return 'N/A';
+        }
 
-		$nip   = gethostbyname($ip);
-		$ipdot = explode('.', $nip);
+        $nip   = gethostbyname($ip);
+        $ipdot = explode('.', $nip);
 
-		if ($ipdot[0] < 0 || $ipdot[0] > 255 || count($ipdot) !== 4)
-		{
-			return 'N/A';
-		}
+        if ($ipdot[0] < 0 || $ipdot[0] > 255 || count($ipdot) !== 4)
+        {
+            return 'N/A';
+        }
 
-		if (isset(self::$cached[$nip]) === TRUE)
-		{
-			return self::$cached[$nip];
-		}
+        if (isset(self::$cached[$nip]) === TRUE)
+        {
+            return self::$cached[$nip];
+        }
 
-		if (self::$fp === NULL)
-		{
-			self::init();
-		}
+        if (self::$fp === NULL)
+        {
+            self::init();
+        }
 
-		$nip2 = pack('N', ip2long($nip));
+        $nip2 = pack('N', ip2long($nip));
 
-		$tmp_offset = (int)$ipdot[0] * 4;
-		$start	  = unpack('Vlen', self::$index[$tmp_offset] . self::$index[$tmp_offset + 1] . self::$index[$tmp_offset + 2] . self::$index[$tmp_offset + 3]);
+        $tmp_offset = (int)$ipdot[0] * 4;
+        $start      = unpack('Vlen', self::$index[$tmp_offset] . self::$index[$tmp_offset + 1] . self::$index[$tmp_offset + 2] . self::$index[$tmp_offset + 3]);
 
-		$index_offset = $index_length = NULL;
-		$max_comp_len = self::$offset['len'] - 1024 - 4;
-		for ($start = $start['len'] * 8 + 1024; $start < $max_comp_len; $start += 8)
-		{
-			if (self::$index{$start} . self::$index{$start + 1} . self::$index{$start + 2} . self::$index{$start + 3} >= $nip2)
-			{
-				$index_offset = unpack('Vlen', self::$index{$start + 4} . self::$index{$start + 5} . self::$index{$start + 6} . "\x0");
-				$index_length = unpack('Clen', self::$index{$start + 7});
+        $index_offset = $index_length = NULL;
+        $max_comp_len = self::$offset['len'] - 1024 - 4;
+        for ($start = $start['len'] * 8 + 1024; $start < $max_comp_len; $start += 8)
+        {
+            if (self::$index{$start} . self::$index{$start + 1} . self::$index{$start + 2} . self::$index{$start + 3} >= $nip2)
+            {
+                $index_offset = unpack('Vlen', self::$index{$start + 4} . self::$index{$start + 5} . self::$index{$start + 6} . "\x0");
+                $index_length = unpack('Clen', self::$index{$start + 7});
 
-				break;
-			}
-		}
+                break;
+            }
+        }
 
-		if ($index_offset === NULL)
-		{
-			return 'N/A';
-		}
+        if ($index_offset === NULL)
+        {
+            return 'N/A';
+        }
 
-		self::$cached[$nip] = explode("\t", shmop_read(self::$fp, self::$offset['len'] + $index_offset['len'] - 1024, $index_length['len']));
+        self::$cached[$nip] = explode("\t", shmop_read(self::$fp, self::$offset['len'] + $index_offset['len'] - 1024, $index_length['len']));
 
-		return self::$cached[$nip];
-	}
+        return self::$cached[$nip];
+    }
 
-	private static function init()
-	{
-		if (self::$fp === NULL)
-		{
-			self::$ip = new self();
-			$sharedFile = __DIR__ . '/17monipdb.dat';
-			$f2k = ftok($sharedFile, 't');
-			self::$fp = shmop_open($f2k, 'a', 0, 0);
-			if(self::$fp === FALSE){
-				self::$fp = shmop_open($f2k, 'c', 0644, filesize($sharedFile));
-				shmop_write(self::$fp, file_get_contents($sharedFile), 0);
-			}
-			if (self::$fp === FALSE)
-			{
-				throw new Exception('Invalid 17monipdb.dat file!');
-			}
-			self::$offset = unpack('Nlen', shmop_read(self::$fp, 0, 4));
-			if (self::$offset['len'] < 4)
-			{
-				throw new Exception('Invalid 17monipdb.dat file!');
-			}
+    private static function init()
+    {
+        if (self::$fp === NULL)
+        {
+            self::$ip = new self();
+            $sharedFile = __DIR__ . '/17monipdb.dat';
+            $f2k = ftok($sharedFile, 't');
+            self::$fp = shmop_open($f2k, 'a', 0, 0);
+            if(self::$fp === FALSE){
+                self::$fp = shmop_open($f2k, 'c', 0644, filesize($sharedFile));
+                shmop_write(self::$fp, file_get_contents($sharedFile), 0);
+            }
+            if (self::$fp === FALSE)
+            {
+                throw new Exception('Invalid 17monipdb.dat file!');
+            }
+            self::$offset = unpack('Nlen', shmop_read(self::$fp, 0, 4));
+            if (self::$offset['len'] < 4)
+            {
+                throw new Exception('Invalid 17monipdb.dat file!');
+            }
 
-			self::$index = shmop_read(self::$fp, 4, self::$offset['len'] - 4);
-		}
-	}
+            self::$index = shmop_read(self::$fp, 4, self::$offset['len'] - 4);
+        }
+    }
 
-	public function __destruct()
-	{
-		if (self::$fp !== NULL)
-		{
-			shmop_close(self::$fp);
-		}
-	}
+    public function __destruct()
+    {
+        if (self::$fp !== NULL)
+        {
+            shmop_close(self::$fp);
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
使用 php 的 shmop 库将 dat 文件放到内存里，提高解析速度，并降低磁盘 IO 消耗。